### PR TITLE
fix: feature-detect getApiKeyAndHeaders for forked pi-coding-agent hosts

### DIFF
--- a/packages/pi-behavior-monitors/index.ts
+++ b/packages/pi-behavior-monitors/index.ts
@@ -1171,6 +1171,29 @@ let cachedAgentLoader: ((name: string) => AgentSpec) | null = null;
 /** Module-level cached template environment for classify agent specs, populated at session_start. */
 let cachedMonitorAgentEnv: nunjucks.Environment | null = null;
 
+type AuthResult = { ok: true; apiKey: string; headers?: Record<string, string> } | { ok: false; error: string };
+
+/**
+ * Resolve model auth across pi-coding-agent API versions.
+ *
+ * Newer upstream (`@mariozechner/pi-coding-agent` ≥ 0.67.x) exposes
+ * `ModelRegistry.getApiKeyAndHeaders(model)` returning `{ ok, apiKey, headers }`.
+ * The OMP fork (`@oh-my-pi/pi-coding-agent`) and older releases only expose
+ * `getApiKey(model)` which returns the key string directly. Feature-detect
+ * and fall back so monitors work on both hosts.
+ */
+async function resolveModelAuth(registry: any, model: Model<Api>): Promise<AuthResult> {
+	if (typeof registry.getApiKeyAndHeaders === "function") {
+		return await registry.getApiKeyAndHeaders(model);
+	}
+	if (typeof registry.getApiKey === "function") {
+		const apiKey = await registry.getApiKey(model);
+		if (apiKey) return { ok: true, apiKey, headers: {} };
+		return { ok: false, error: `No API key for ${model.provider}/${model.id}` };
+	}
+	return { ok: false, error: "modelRegistry exposes neither getApiKeyAndHeaders nor getApiKey" };
+}
+
 /**
  * Classify via agent spec — the sole classify path.
  * Loads the agent YAML, builds context from collectors, compiles via
@@ -1225,7 +1248,7 @@ async function classifyViaAgent(
 	const model = ctx.modelRegistry.find(provider, modelId);
 	if (!model) throw new Error(`Model ${modelSpec} not found`);
 
-	const auth = await ctx.modelRegistry.getApiKeyAndHeaders(model);
+	const auth = await resolveModelAuth(ctx.modelRegistry, model);
 	if (!auth.ok) throw new Error(auth.error);
 
 	// Thinking is disabled for classify calls — Anthropic API rejects

--- a/packages/pi-workflows/src/step-monitor.ts
+++ b/packages/pi-workflows/src/step-monitor.ts
@@ -18,6 +18,25 @@ import { persistStepOutput } from "./output.js";
 import { zeroUsage } from "./step-shared.js";
 import type { StepResult } from "./types.js";
 
+type AuthResult = { ok: true; apiKey: string; headers?: Record<string, string> } | { ok: false; error: string };
+
+/**
+ * Resolve model auth across pi-coding-agent API versions.
+ * Newer upstream exposes `getApiKeyAndHeaders`; older/forked hosts only
+ * expose `getApiKey`. Feature-detect so monitors work on both.
+ */
+async function resolveModelAuth(registry: any, model: Model<Api>): Promise<AuthResult> {
+	if (typeof registry.getApiKeyAndHeaders === "function") {
+		return await registry.getApiKeyAndHeaders(model);
+	}
+	if (typeof registry.getApiKey === "function") {
+		const apiKey = await registry.getApiKey(model);
+		if (apiKey) return { ok: true, apiKey, headers: {} };
+		return { ok: false, error: `No API key for ${model.provider}/${model.id}` };
+	}
+	return { ok: false, error: "modelRegistry exposes neither getApiKeyAndHeaders nor getApiKey" };
+}
+
 // ── Monitor spec types (subset of pi-behavior-monitors) ──────────────────────
 
 interface MonitorSpec {
@@ -280,7 +299,7 @@ export async function executeMonitor(
 		};
 	}
 
-	const auth = await options.ctx.modelRegistry.getApiKeyAndHeaders(model);
+	const auth = await resolveModelAuth(options.ctx.modelRegistry, model);
 	if (!auth.ok) {
 		return {
 			step: stepName,


### PR DESCRIPTION
## Problem

Extensions bundled in pi-behavior-monitors and pi-workflows call
`ctx.modelRegistry.getApiKeyAndHeaders(model)` unconditionally. That
method was added upstream in `@mariozechner/pi-coding-agent@0.67.x`,
but it does not exist on:

- `@oh-my-pi/pi-coding-agent` (the OMP/oh-my-pi fork — current v14.1.2 has only `getApiKey`)
- older `@mariozechner/pi-coding-agent` releases still in the wild

On those hosts, every hedge classification throws:

```
Error: [hedge] Classification failed:
  ctx.modelRegistry.getApiKeyAndHeaders is not a function.
```

Monitors fall open (`classifyFailures` trips the 3-strike back-off),
so steering never fires.

## Fix

Add a local `resolveModelAuth` helper at both call sites
(`pi-behavior-monitors/index.ts` and `pi-workflows/src/step-monitor.ts`)
that feature-detects `getApiKeyAndHeaders` and falls back to
`getApiKey`, normalising to the `{ ok, apiKey, headers }` shape the
rest of the classify path already expects.

This mirrors what `@guwidoe/pi-prompt-suggester` already does, and
keeps behaviour unchanged on upstream `@mariozechner/pi-coding-agent@0.67+`.

## Verification

- `npm run build` — clean
- `npm run check` — 0 errors (pre-existing biome schema info unchanged)
- Behaviour identical on `getApiKeyAndHeaders` hosts; graceful fallback on `getApiKey`-only hosts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)